### PR TITLE
Feature/update subset

### DIFF
--- a/.github/workflows/pytest_pv.yml
+++ b/.github/workflows/pytest_pv.yml
@@ -3,7 +3,7 @@ on:
     push:
         branches: [main, develop, release/*]
         tags:
-            - '*'
+            - '*.*.*'
         paths-ignore:
             - "docs/**"
             - "**.md"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,7 +6,7 @@ name: Publish package to PyPI
 on:
     push:
         tags:
-            - "*"
+            - "*.*.*"
 
 jobs:
     build:

--- a/postprocessing_variant_calls/maf/concat/concat_helpers.py
+++ b/postprocessing_variant_calls/maf/concat/concat_helpers.py
@@ -32,7 +32,7 @@ def check_maf(files: List[Path]):
     extensions = [os.path.splitext(f)[1] for f in files]
     for ext in extensions:
         if ext not in acceptable_extensions:
-            typer.secho(f"If using files argument, all files must be mafs.", fg=typer.colors.RED)
+            typer.secho(f"If using files argument, all files must be mafs using the same extension.", fg=typer.colors.RED)
             raise typer.Abort()
     return files
 
@@ -52,11 +52,12 @@ def check_headers(maf, header):
     if set(header).issubset(columns_set):
             return maf[header]
     else:
+        list(set(header) - columns_set)
         typer.secho(f"{columns_set} is not a subset of {header}. Please provide custom header file if the provided a header file or edit the current header file if you maf uses different columns names", 
                     fg=typer.colors.RED)
         raise typer.Abort()
     
-def concat_mafs(files, output_maf, header):
+def concat_mafs(files, output_maf, header, separator):
     """main function for annotation a bed file
 
     Args:
@@ -72,7 +73,7 @@ def concat_mafs(files, output_maf, header):
         if Path(maf).is_file():
             # Read maf file
             typer.secho(f"Reading: {maf}", fg=typer.colors.BRIGHT_GREEN)
-            maf_df = pd.read_csv(maf, sep="\t", low_memory=True)
+            maf_df = pd.read_csv(maf, sep=separator, low_memory=True)
             # header
             maf_col_df = check_headers(maf_df, header)
             maf_list.append(maf_col_df)

--- a/postprocessing_variant_calls/maf/concat/resources.py
+++ b/postprocessing_variant_calls/maf/concat/resources.py
@@ -35,4 +35,4 @@ de_duplication_columns = [
                 "HGVSp",
                 "HGVSp_Short",
 ]
-acceptable_extensions = ['.maf', '.txt']
+acceptable_extensions = ['.maf', '.txt', '.csv']

--- a/postprocessing_variant_calls/maf/main.py
+++ b/postprocessing_variant_calls/maf/main.py
@@ -94,7 +94,7 @@ def maf_maf(
     if deduplicate:
         concat_df = concat_df[de_duplication_columns].drop_duplicates()
     # write out paths
-    concat_df.to_csv(f"{output_maf}.maf", index=False, sep="\t")
+    concat_df.to_csv(output_maf, index=False, sep="\t")
     return 0
 
 # Add Subset App 

--- a/postprocessing_variant_calls/maf/main.py
+++ b/postprocessing_variant_calls/maf/main.py
@@ -128,6 +128,12 @@ def subset_maf(
         "-c",
         help="Name of the column header to be used for sub-setting",
     ),
+    separator: str = typer.Option(
+        "\t",
+        "--separator",
+        "-sep",
+        help="Specify a seperator for delimited data.",
+    ),
 ):
 
     """
@@ -148,9 +154,10 @@ def subset_maf(
             typer.echo("Identifiers were not provided via command line as well")
             raise typer.Abort()
 
-    maf_df = read_tsv(maf)
+    maf_df = read_tsv(maf, separator)
     ids_to_subset = read_ids(sid, ids)
     subset_maf = filter_by_rows(ids_to_subset, maf_df, col_name)
+    typer.echo(f"Writing to {output_file}")
     subset_maf.drop_duplicates().to_csv(output_file, sep="\t", index=False)
     typer.echo("Done!")
 

--- a/postprocessing_variant_calls/maf/main.py
+++ b/postprocessing_variant_calls/maf/main.py
@@ -36,14 +36,14 @@ def maf_maf(
         None, 
         "--files",
         "-f",
-        help="MAF file to concatenate. Maf files are specified here, or using paths parameter.",
-        # callback = check_maf # call back allow us to check input parameters
+        help="MAF file to concatenate. Default assumes MAFs are tsv. MAF inputs are specified here, or using paths parameter",
+        callback = check_maf # call back allow us to check input parameters
     ),
     paths: Path = typer.Option(
         None,
         "--paths",
         "-p",
-        help="A text file containing paths of maf files to concatenate. Maf files are specified here, or using files parameter.",
+        help="A text file containing paths of maf files to concatenate. Default assumes MAFs are tsv. MAF files are specified here, or using files parameter.",
         callback = check_txt # call back allow us to check input parameters
     ),
     output_maf: Path = typer.Option(

--- a/postprocessing_variant_calls/maf/main.py
+++ b/postprocessing_variant_calls/maf/main.py
@@ -37,7 +37,7 @@ def maf_maf(
         "--files",
         "-f",
         help="MAF file to concatenate. Maf files are specified here, or using paths parameter.",
-        callback = check_maf # call back allow us to check input parameters
+        # callback = check_maf # call back allow us to check input parameters
     ),
     paths: Path = typer.Option(
         None,
@@ -64,7 +64,14 @@ def maf_maf(
         '--deduplicate',
         "-de",
         help="deduplicate outputted maf file.",
-    )
+    ),
+    separator: str = typer.Option(
+        "tsv",
+        "--separator",
+        "-sep",
+        help="Specify a seperator for delimited data.",
+        callback= check_separator
+    ),
 ):
     logger.info("started concat")
     # make sure files or paths was specified
@@ -82,7 +89,7 @@ def maf_maf(
         header = process_header(header)
     # concat maf files 
     # paths vs files is taken care of at this point
-    concat_df = concat_mafs(files, output_maf, header)
+    concat_df = concat_mafs(files, output_maf, header, separator)
     # deduplicate 
     if deduplicate:
         concat_df = concat_df[de_duplication_columns].drop_duplicates()
@@ -159,7 +166,7 @@ def subset_maf(
     ids_to_subset = read_ids(sid, ids)
     subset_maf = filter_by_rows(ids_to_subset, maf_df, col_name)
     typer.echo(f"Writing to {output_file}")
-    subset_maf.drop_duplicates().to_csv(output_file, sep=",", index=False)
+    subset_maf.drop_duplicates().to_csv(output_file, sep="\t", index=False)
     typer.echo("Done!")
 
 if __name__ == "__main__":

--- a/postprocessing_variant_calls/maf/main.py
+++ b/postprocessing_variant_calls/maf/main.py
@@ -2,7 +2,7 @@ from .annotate import annotate_process
 from .concat import concat_process
 from .concat.concat_helpers import concat_mafs, check_maf, check_txt, process_paths, process_header
 from .concat.resources import de_duplication_columns, minimal_maf_columns
-from .subset.subset_helpers import read_tsv, read_ids, filter_by_rows
+from .subset.subset_helpers import read_tsv, read_ids, filter_by_rows, check_separator
 import typer 
 import logging
 from pathlib import Path
@@ -129,10 +129,11 @@ def subset_maf(
         help="Name of the column header to be used for sub-setting",
     ),
     separator: str = typer.Option(
-        "\t",
+        "tsv",
         "--separator",
         "-sep",
         help="Specify a seperator for delimited data.",
+        callback= check_separator
     ),
 ):
 
@@ -158,7 +159,7 @@ def subset_maf(
     ids_to_subset = read_ids(sid, ids)
     subset_maf = filter_by_rows(ids_to_subset, maf_df, col_name)
     typer.echo(f"Writing to {output_file}")
-    subset_maf.drop_duplicates().to_csv(output_file, sep="\t", index=False)
+    subset_maf.drop_duplicates().to_csv(output_file, sep=",", index=False)
     typer.echo("Done!")
 
 if __name__ == "__main__":

--- a/postprocessing_variant_calls/maf/subset/subset_helpers.py
+++ b/postprocessing_variant_calls/maf/subset/subset_helpers.py
@@ -83,6 +83,14 @@ def get_row(tsv_file):
     with open(tsv_file, "r") as FH:
         skipped.extend(i for i, line in enumerate(FH) if line.startswith("#"))
     return skipped
+def check_separator(separator: str):
+    separator_dict = {"tsv":'\t', "csv":","}
+    if separator in separator_dict.keys():
+        sep = separator_dict[separator]
+    else:
+        typer.secho(f"Separator for delimited file must be 'tsv' or 'csv', not '{separator}'", fg=typer.colors.RED)
+        raise typer.Abort()
+    return sep
 
 if __name__ == "__main__":
     app()

--- a/postprocessing_variant_calls/maf/subset/subset_helpers.py
+++ b/postprocessing_variant_calls/maf/subset/subset_helpers.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 app = typer.Typer()
 
-def read_tsv(tsv):
+def read_tsv(tsv, separator):
     """Read a tsv file
 
     Args:
@@ -14,9 +14,9 @@ def read_tsv(tsv):
     Returns:
         data_frame: Output a data frame containing the MAF/tsv
     """
-    typer.echo("Read TSV file...")
+    typer.echo("Read Delimited file...")
     skip = get_row(tsv)
-    return pd.read_csv(tsv, sep="\t", skiprows=skip, low_memory=False)
+    return pd.read_csv(tsv, sep=separator, skiprows=skip, low_memory=False)
 
 
 def read_ids(sid, ids):

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -8,13 +8,13 @@ runner = CliRunner()
 maf_concat_files = [
         ['maf', 'concat', '-f', 'tests/data/maf/concat/maf2.maf' , 
         '-f', 'tests/data/maf/concat/maf1.maf', 
-        "-o", "tests/data/maf/concat/output_maf", "-h" ,"resources/maf_concat/header.txt"] 
+        "-o", "tests/data/maf/concat/output_maf.maf", "-h" ,"resources/maf_concat/header.txt"] 
 
 ]
 
 maf_concat_paths = [
         ['maf', 'concat', '-p', 'tests/data/maf/concat/paths.txt' ,  
-        "-o", "tests/data/maf/concat/output_maf", "-h", "resources/maf_concat/header.txt"] 
+        "-o", "tests/data/maf/concat/output_maf.maf", "-h", "resources/maf_concat/header.txt"] 
 
 ]
 


### PR DESCRIPTION
Adjusting maf `subset` and `concat` to accommodate dmp and cmo genotyping workflow.
- adding separator argument to both commands.
- allow csv files to be concatenated 
- other docs and testing updates 