### PR TITLE
Creating split_by_annotations command to subset filtered MAF file to separate text files used in mPATH

### DIFF
--- a/postprocessing_variant_calls/maf/annotate/annotate_process.py
+++ b/postprocessing_variant_calls/maf/annotate/annotate_process.py
@@ -151,6 +151,11 @@ def maf_tsv(
         "-v",
         help="name for annotation column. Defaults to (Yes, No)",
     ),
+    split_by_annotations: str = typer.Option(
+        "false",
+        "--split_by_annotations",
+        help="Flag for invoking splitting the input MAF file by annotations (run at end of nucleovar). Defaults to false",
+    ),
 ):
     # prep maf
     mafa = MAFFile(maf, separator)

--- a/postprocessing_variant_calls/maf/annotate/annotate_process.py
+++ b/postprocessing_variant_calls/maf/annotate/annotate_process.py
@@ -23,6 +23,9 @@ from postprocessing_variant_calls.maf.helper import (
     MAFFile,
     gen_id_tsv,
 )
+from postprocessing_variant_calls.maf.tag.tag_process import (
+    split_by_annotations,
+)
 from utils.pybed_intersect import annotater
 import pandas as pd
 import numpy as np
@@ -152,22 +155,27 @@ def maf_tsv(
         help="name for annotation column. Defaults to (Yes, No)",
     ),
     split_by_annotations: str = typer.Option(
-        "false",
+        "False",
         "--split_by_annotations",
         help="Flag for invoking splitting the input MAF file by annotations (run at end of nucleovar). Defaults to false",
     ),
 ):
     # prep maf
-    mafa = MAFFile(maf, separator)
+    if split_by_annotations == False:
+        mafa = MAFFile(maf, separator)
 
-    # prep tsv
-    tsva = read_tsv(tsv, separator)
-    tsva = gen_id_tsv(tsva)
+        # prep tsv
+        tsva = read_tsv(tsv, separator)
+        tsva = gen_id_tsv(tsva)
 
-    # annotate maf with processed bed file
-    annotated_maf = mafa.annotate_maf_maf(tsva, oc, values)
-    # write out paths
-    annotated_maf.to_csv(output_maf, index=False, sep="\t")
+        # annotate maf with processed bed file
+        annotated_maf = mafa.annotate_maf_maf(tsva, oc, values)
+        # write out paths
+        annotated_maf.to_csv(output_maf, index=False, sep="\t")
+    else:
+        split_by_annotations(maf,output_maf)
+        # make a call to the split by annotations function
+        
     return 0
 
 

--- a/postprocessing_variant_calls/maf/annotate/annotate_process.py
+++ b/postprocessing_variant_calls/maf/annotate/annotate_process.py
@@ -154,28 +154,18 @@ def maf_tsv(
         "-v",
         help="name for annotation column. Defaults to (Yes, No)",
     ),
-    split_by_annotations: str = typer.Option(
-        "False",
-        "--split_by_annotations",
-        help="Flag for invoking splitting the input MAF file by annotations (run at end of nucleovar). Defaults to false",
-    ),
 ):
     # prep maf
-    if split_by_annotations == False:
-        mafa = MAFFile(maf, separator)
+    mafa = MAFFile(maf, separator)
 
-        # prep tsv
-        tsva = read_tsv(tsv, separator)
-        tsva = gen_id_tsv(tsva)
+    # prep tsv
+    tsva = read_tsv(tsv, separator)
+    tsva = gen_id_tsv(tsva)
 
-        # annotate maf with processed bed file
-        annotated_maf = mafa.annotate_maf_maf(tsva, oc, values)
-        # write out paths
-        annotated_maf.to_csv(output_maf, index=False, sep="\t")
-    else:
-        split_by_annotations(maf,output_maf)
-        # make a call to the split by annotations function
-        
+    # annotate maf with processed bed file
+    annotated_maf = mafa.annotate_maf_maf(tsva, oc, values)
+    # write out paths
+    annotated_maf.to_csv(output_maf, index=False, sep="\t")
     return 0
 
 

--- a/postprocessing_variant_calls/maf/annotate/workflow.txt
+++ b/postprocessing_variant_calls/maf/annotate/workflow.txt
@@ -1,0 +1,3 @@
+changes being made to annotation process functions
+
+1. mafbytsv calls "split_by_annotation" function if the flag is invoked (split_by_annotation is located in pv maf tag for now)

--- a/postprocessing_variant_calls/maf/helper.py
+++ b/postprocessing_variant_calls/maf/helper.py
@@ -449,3 +449,8 @@ class MAFFile:
                 fg=typer.colors.RED,
             )
             raise typer.Abort()
+        
+    def split_by_annotations_subset(self):
+        # Replace "-" in column headers to "_" so that they can be
+        #  used as attributes to a variant object
+        

--- a/postprocessing_variant_calls/maf/tag/tag_constants.py
+++ b/postprocessing_variant_calls/maf/tag/tag_constants.py
@@ -1,0 +1,762 @@
+import os
+import re
+from collections import OrderedDict
+
+# Repository main directory
+ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+
+
+#############
+# Resources #
+#############
+RESOURCES_FOLDER = os.path.join(ROOT_DIR, "resources")
+TEMPLATES_FOLDER = os.path.join(RESOURCES_FOLDER, "templates")
+
+CNV_INPUTS = os.path.join(TEMPLATES_FOLDER, "cnv.yaml")
+COLLAPSING_INPUTS = os.path.join(TEMPLATES_FOLDER, "collapsing.yaml")
+MSI_INPUTS = os.path.join(TEMPLATES_FOLDER, "msi.yaml")
+SV_INPUTS = os.path.join(TEMPLATES_FOLDER, "sv.yaml")
+VARIANTS_INPUTS = os.path.join(TEMPLATES_FOLDER, "variants.yaml")
+
+VERSION_PARAM = os.path.join(RESOURCES_FOLDER, "version.yaml")
+
+##################################
+# SampleSheet Column Definitions #
+##################################
+SAMPLE_SHEET__LANE_COLUMN = "Lane"
+SAMPLE_SHEET__SAMPLE_ID_COLUMN = "Sample_ID"
+SAMPLE_SHEET__PATIENT_ID_COLUMN = "Sample_Name"
+SAMPLE_SHEET__BARCODE_ID1_COLUMN = "I7_Index_ID"
+SAMPLE_SHEET__BARCODE_INDEX_1_COLUMN = "index"
+SAMPLE_SHEET__BARCODE_ID2_COLUMN = "I5_Index_ID"
+SAMPLE_SHEET__BARCODE_INDEX_2_COLUMN = "index2"
+SAMPLE_SHEET__CLASS_COLUMN = "Description"
+SAMPLE_SHEET__METADATA_COLUMN = "Operator"
+SAMPLE_SHEET__PROJECT_ID_COLUMN = "Sample_Project"
+
+
+################################
+# TitleFile Column Definitions #
+################################
+
+# Columns explicitly provided in sample sheet
+TITLE_FILE__POOL_COLUMN = "Pool"
+TITLE_FILE__SAMPLE_ID_COLUMN = "Sample"
+TITLE_FILE__PATIENT_ID_COLUMN = "Patient_ID"
+TITLE_FILE__SAMPLE_CLASS_COLUMN = "Class"
+TITLE_FILE__BARCODE_INDEX_1_COLUMN = "Barcode_index_1"
+TITLE_FILE__BARCODE_INDEX_2_COLUMN = "Barcode_index_2"
+TITLE_FILE__LANE_COLUMN = "Lane"
+
+# Columns inferred from other columns defined above
+TITLE_FILE__SAMPLE_TYPE_COLUMN = "Sample_type"
+TITLE_FILE__BAIT_VERSION_COLUMN = "Bait_version"
+
+# Columns defined as constants
+TITLE_FILE__COLLAB_ID_COLUMN = "Collab_ID"
+
+# Columns inferred from samplesheet metadata/operator column
+TITLE_FILE__SEX_COLUMN = "Sex"
+TITLE_FILE__PATIENT_NAME_COLUMN = "PatientName"
+TITLE_FILE__ACCESSION_COLUMN = "AccessionID"
+TITLE_FILE__SEQUENCER_COLUMN = "Sequencer"
+
+# TODO:
+# Columns currently filled with dummy values until DMS/LIMS figures out a way.
+TITLE_FILE__POOL_INPUT_COLUMN = "Pool_input"
+
+# Columns not current used
+TITLE_FILE__BARCODE_ID_COLUMN = "Barcode"
+TITLE_FILE__INPUT_NG_COLUMN = "Input_ng"
+TITLE_FILE__LIBRARY_YIELD_COLUMN = "Library_yield"
+TITLE_FILE__DNA_YIELD_COLUMN = "Extracted_DNA_Yield"
+
+
+##########################
+# Map Column Definitions #
+##########################
+
+# Map SAMPLESHEET --> TITLE_FILE
+# Use OrderedDict to keep ordering for keys() and values()
+columns_map_samplesheet = OrderedDict(
+    [
+        (SAMPLE_SHEET__PROJECT_ID_COLUMN, TITLE_FILE__POOL_COLUMN),
+        (SAMPLE_SHEET__SAMPLE_ID_COLUMN, TITLE_FILE__SAMPLE_ID_COLUMN),
+        (SAMPLE_SHEET__PATIENT_ID_COLUMN, TITLE_FILE__PATIENT_ID_COLUMN),
+        (SAMPLE_SHEET__CLASS_COLUMN, TITLE_FILE__SAMPLE_CLASS_COLUMN),
+        (SAMPLE_SHEET__BARCODE_INDEX_1_COLUMN, TITLE_FILE__BARCODE_INDEX_1_COLUMN),
+        (SAMPLE_SHEET__BARCODE_INDEX_2_COLUMN, TITLE_FILE__BARCODE_INDEX_2_COLUMN),
+        (SAMPLE_SHEET__LANE_COLUMN, TITLE_FILE__LANE_COLUMN),
+    ]
+)
+
+
+###################################
+# Title file generation constants #
+###################################
+COLLAB_ID = "DMP"
+PLASMA = "Plasma"
+BUFFY = "Buffy Coat"
+SAMPLE_ID_ALLOWED_DELIMETER = "-"
+DISALLOWED_SAMPLE_ID_CHARACTERS = "!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~"
+METADATA_COLUMN_DELIMETER = "|"
+METADATA_REQUIRED_COLUMNS = [1, 2, 3, 4]
+SELECT_SPLIT_COLUMN = -1
+ALLOWED_SAMPLE_TYPE = re.compile(r"(^TP|^TB|^N)")
+ALLOWED_SAMPLE_TYPE_LIST = ["TB", "NB", "N", "TP", "NP"]
+PLASMA_SAMPLE_TYPE = re.compile(r"(^TP|^NP)")
+# PLASMA_SAMPLE_TYPE = ["TP", "NP", "T"]
+BUFFY_SAMPLE_TYPE = re.compile(r"(^TB|^N)")
+# BUFFY_SAMPLE_TYPE = ["TB", "NB", "N"]
+ALLOWED_SAMPLE_DESCRIPTION = ["Tumor", "Normal", "PoolTumor", "PoolNormal"]
+ALLOWED_SAMPLE_TYPE_DESCRIPTION = [PLASMA, BUFFY]
+ALLOWED_CONTROLS = ["PoolTumor", "PoolNormal"]
+CONTROL_SAMPLE_KEYWORD = "SeraCare"
+ALLOWED_SEX = ["Male", "Female"]
+CONTROL_SAMPLE_SEX = ["Control", "-"]
+FEMALE = "Female"
+ALLOWED_SEQUENCERS = ["HISEQ", "NOVASEQ"]
+EXPECTED_BAIT_VERSION = "v1"
+ASSAY_NAME = "ACCESS"
+PROJECT_NAME = re.compile("^" + ASSAY_NAME + "v[0-9]-[A-Za-z]+-[0-9]{8}.*")
+BAIT_SEARCH = re.compile("^" + ASSAY_NAME + "v[0-9]")
+MERGED_LANE_VALUE = "0"
+
+SAMPLE_SHEET_REQUIRED_COLUMNS = [
+    "Lane",
+    "Sample_ID",
+    "Sample_Name",
+    "I7_Index_ID",
+    "index",
+    "I5_Index_ID",
+    "index2",
+    "Description",
+    "Control",
+    "Operator",
+    "Sample_Project",
+]
+
+SAMPLE_SHEET_OPTIONAL_COLUMNS = [
+    "FCID",
+    "Sample_Plate",
+    "Sample_Well",
+    "Sample_Ref",
+    "Control",
+    "Recipe",
+]
+
+TITLE_FILE__COLUMN_ORDER = [
+    TITLE_FILE__BARCODE_ID_COLUMN,
+    TITLE_FILE__POOL_COLUMN,
+    TITLE_FILE__SAMPLE_ID_COLUMN,
+    TITLE_FILE__COLLAB_ID_COLUMN,
+    TITLE_FILE__PATIENT_ID_COLUMN,
+    TITLE_FILE__SAMPLE_CLASS_COLUMN,
+    TITLE_FILE__SAMPLE_TYPE_COLUMN,
+    TITLE_FILE__POOL_INPUT_COLUMN,
+    TITLE_FILE__BAIT_VERSION_COLUMN,
+    TITLE_FILE__SEX_COLUMN,
+    TITLE_FILE__PATIENT_NAME_COLUMN,
+    TITLE_FILE__ACCESSION_COLUMN,
+    TITLE_FILE__BARCODE_INDEX_1_COLUMN,
+    TITLE_FILE__BARCODE_INDEX_2_COLUMN,
+    TITLE_FILE__LANE_COLUMN,
+]
+
+##############################
+# Pipeline Kickoff Constants #
+##############################
+
+FASTQ_1_FILE_SEARCH = "_R1_001.fastq.gz"
+FASTQ_2_FILE_SEARCH = "_R2_001.fastq.gz"
+SAMPLE_SHEET_FILE_SEARCH = "SampleSheet.csv"
+
+ADAPTER_1 = "GATCGGAAGAGC"
+ADAPTER_2 = "AGATCGGAAGAGC"
+
+NON_REVERSE_COMPLEMENTED = 0
+REVERSE_COMPLEMENTED = 1
+
+# Delimiter for printing logs
+DELIMITER = "\n" + "*" * 20 + "\n"
+# Delimiter for inputs file sections
+INPUTS_FILE_DELIMITER = "\n" + "# " + "--" * 30 + "\n"
+
+# Template identifier string that will get replaced with the project root location
+PIPELINE_ROOT_PLACEHOLDER = "$PIPELINE_ROOT"
+
+BAM_REGEX = re.compile(r".*\.bam$")
+
+SAMPLE_SEP_FASTQ_DELIMETER = "_"
+SAMPLE_SEP_DIR_DELIMETER = "/"
+
+
+##########################
+# Constants for QC files #
+##########################
+
+# Avoid division by zero errors
+EPSILON = 1e-9
+
+# Shorter reference to sample ID column, to be used everywhere
+SAMPLE_ID_COLUMN = TITLE_FILE__SAMPLE_ID_COLUMN
+
+# WALTZ Metrics Files Constants
+
+# File suffixes
+WALTZ_READ_COUNTS_FILENAME_SUFFIX = ".read-counts"
+WALTZ_FRAGMENT_SIZES_FILENAME_SUFFIX = ".fragment-sizes"
+WALTZ_INTERVALS_FILENAME_SUFFIX = "-intervals.txt"
+WALTZ_INTERVALS_WITHOUT_DUPLICATES_FILENAME_SUFFIX = "-intervals-without-duplicates.txt"
+
+TOTAL_OFF_TARGET_FRACTION_COLUMN = "total_off_target_fraction"
+
+WALTZ_CHROMOSOME_COLUMN = "chromosome"
+WALTZ_START_COLUMN = "start"
+WALTZ_STOP_COLUMN = "stop"
+WALTZ_INTERVAL_NAME_COLUMN = "interval_name"
+WALTZ_FRAGMENT_SIZE_COLUMN = "fragment_size"
+WALTZ_PEAK_COVERAGE_COLUMN = "peak_coverage"
+WALTZ_AVERAGE_COVERAGE_COLUMN = "TotalCoverage"
+WALTZ_GC_CONTENT_COLUMN = "gc"
+
+# todo
+WALTZ_INTERVALS_FILE_HEADER = [
+    WALTZ_CHROMOSOME_COLUMN,
+    WALTZ_START_COLUMN,
+    WALTZ_STOP_COLUMN,
+    WALTZ_INTERVAL_NAME_COLUMN,
+    WALTZ_FRAGMENT_SIZE_COLUMN,
+    WALTZ_PEAK_COVERAGE_COLUMN,
+    WALTZ_AVERAGE_COVERAGE_COLUMN,
+    WALTZ_GC_CONTENT_COLUMN,
+]
+
+WALTZ_COVERAGE_FILE_HEADER = ["TotalCoverage", "UniqueCoverage"]
+
+
+# AGBM Metrics Files Constants
+#
+# Column names
+AGBM_COVERAGE_FILENAME = "waltz-coverage.txt"
+AGBM_READ_COUNTS_FILENAME = "read-counts.txt"
+AGBM_FRAGMENT_SIZES_FILENAME = "fragment-sizes.txt"
+AGBM_INTERVALS_COVERAGE_SUM_FILENAME = "intervals_coverage_sum.txt"
+
+
+# fragment-sizes.txt
+FRAGMENT_SIZE_COLUMN = "FragmentSize"
+TOTAL_FREQUENCY_COLUMN = "TotalFrequency"
+UNIQUE_FREQUENCY_COLUMN = "UniqueFrequency"
+
+# read-counts.txt
+TOTAL_MAPPED_COLUMN = "TotalMapped"
+UNIQUE_MAPPED_COLUMN = "UniqueMapped"
+TOTAL_READS_COLUMN = "TotalReads"
+UNMAPPED_READS_COLUMN = "UnmappedReads"
+DUPLICATE_FRACTION_COLUMN = "DuplicateFraction"
+TOTAL_ON_TARGET_COLUMN = "TotalOnTarget"
+UNIQUE_ON_TARGET_COLUMN = "UniqueOnTarget"
+TOTAL_ON_TARGET_FRACTION_COLUMN = "TotalOnTargetFraction"
+UNIQUE_ON_TARGET_FRACTION_COLUMN = "UniqueOnTargetFraction"
+
+# File Headers
+AGBM_READ_COUNTS_HEADER = [
+    SAMPLE_ID_COLUMN,
+    "bam",
+    TOTAL_READS_COLUMN,
+    UNMAPPED_READS_COLUMN,
+    TOTAL_MAPPED_COLUMN,
+    UNIQUE_MAPPED_COLUMN,
+    DUPLICATE_FRACTION_COLUMN,
+    TOTAL_ON_TARGET_COLUMN,
+    UNIQUE_ON_TARGET_COLUMN,
+    TOTAL_ON_TARGET_FRACTION_COLUMN,
+    UNIQUE_ON_TARGET_FRACTION_COLUMN,
+]
+
+AGBM_FRAGMENT_SIZES_FILE_HEADER = [
+    SAMPLE_ID_COLUMN,
+    FRAGMENT_SIZE_COLUMN,
+    TOTAL_FREQUENCY_COLUMN,
+    UNIQUE_FREQUENCY_COLUMN,
+]
+
+# Chr\tStart\tEnd\tIntervalName\tLength\tGC\tCoverage\tCoverageWithoutDuplicates
+# intervals-coverage-sum.txt
+CHROMOSOME_COLUMN = "Chr"
+START_COLUMN = "Start"
+END_COLUMN = "End"
+INTERVAL_NAME_COLUMN = "IntervalName"
+LENGTH_COLUMN = "Length"
+GC_COLUMN = "GC"
+COVERAGE_COLUMN = "Coverage"
+COVERAGE_WITH_DUPLICATES_COLUMN = "CoverageWithoutDuplicates"
+
+AGBM_INTERVALS_COVERAGE_SUM_FILE_HEADER = [
+    SAMPLE_ID_COLUMN,
+    CHROMOSOME_COLUMN,
+    START_COLUMN,
+    END_COLUMN,
+    INTERVAL_NAME_COLUMN,
+    LENGTH_COLUMN,
+    GC_COLUMN,
+    COVERAGE_COLUMN,
+    COVERAGE_WITH_DUPLICATES_COLUMN,
+]
+
+AGBM_TOTAL_AVERAGE_COVERAGE_COLUMN = "TotalCoverage"
+AGBM_UNIQUE_AVERAGE_COVERAGE_COLUMN = "UniqueCoverage"
+
+AGBM_COVERAGE_HEADER = [
+    SAMPLE_ID_COLUMN,
+    AGBM_TOTAL_AVERAGE_COVERAGE_COLUMN,
+    AGBM_UNIQUE_AVERAGE_COVERAGE_COLUMN,
+]
+
+
+# TABLES MODULE Files Constants
+#
+# Labels for collapsing methods
+TOTAL_LABEL = "TotalCoverage"
+PICARD_LABEL = "Picard Unique"
+MAPPED_LABEL = "Mapped"
+
+POOL_A_LABEL = "A Targets"
+POOL_B_LABEL = "B Targets"
+
+UNFILTERED_COLLAPSING_METHOD = "All Unique"
+SIMPLEX_COLLAPSING_METHOD = "Simplex"
+DUPLEX_COLLAPSING_METHOD = "Duplex"
+SIMPLEX_DUPLEX_COMBINED = "SimplexDuplex"
+
+# Headers for tables
+DUPLICATION_RATES_HEADER = [SAMPLE_ID_COLUMN, "method", "duplication_rate", "pool"]
+
+GC_BIN_COLUMN = "gc_bin"
+METHOD_COLUMN = "method"
+GC_BIAS_HEADER = [
+    SAMPLE_ID_COLUMN,
+    "interval_name",
+    WALTZ_PEAK_COVERAGE_COLUMN,
+    "gc",
+    "method",
+]
+GC_BIAS_AVERAGE_COVERAGE_ALL_SAMPLES_HEADER = [METHOD_COLUMN, GC_BIN_COLUMN, "coverage"]
+GC_BIAS_AVERAGE_COVERAGE_EACH_SAMPLE_HEADER = [
+    METHOD_COLUMN,
+    SAMPLE_ID_COLUMN,
+    GC_BIN_COLUMN,
+    "coverage",
+]
+
+# Output file names
+read_counts_filename = "read_counts_agg.txt"
+coverage_agg_filename = "coverage_agg.txt"
+gc_avg_each_sample_coverage_filename = (
+    "GC_bias_with_coverage_averages_over_each_sample.txt"
+)
+gc_bias_with_coverage_filename = "GC_bias_with_coverage.txt"
+read_counts_total_filename = "read_counts_total.txt"
+coverage_per_interval_filename = "coverage_per_interval.txt"
+read_counts_table_exon_level_filename = "read_counts_agg_exon_level.txt"
+coverage_table_exon_level_filename = "coverage_agg_exon_level.txt"
+gc_cov_int_table_exon_level_filename = "GC_bias_with_coverage_exon_level.txt"
+gc_avg_each_sample_coverage_exon_level_filename = (
+    "GC_bias_with_coverage_averages_over_each_sample_exon_level.txt"
+)
+average_coverage_across_exon_targets_filename = (
+    "average_coverage_across_exon_targets_duplex_A.txt"
+)
+
+INSERT_SIZE_PREFIX = "insert_sizes_"
+INSERT_SIZE_OUTPUT_FILE_NAMES = [
+    "standard_A_targets.txt",
+    "unfiltered_A_targets.txt",
+    "simplex_A_targets.txt",
+    "duplex_A_targets.txt",
+    "standard_B_targets.txt",
+    "unfiltered_B_targets.txt",
+    "simplex_B_targets.txt",
+    "duplex_B_targets.txt",
+]
+
+EXON_COVERAGE_OUTPUT_FILE_NAMES = [
+    "coverage_per_interval_A_targets_All_Unique.txt",
+    "coverage_per_interval_A_targets_Duplex.txt",
+    "coverage_per_interval_A_targets_Simplex.txt",
+    "coverage_per_interval_A_targets_TotalCoverage.txt",
+]
+
+# Output file names
+read_counts_filename = "read_counts_agg.txt"
+coverage_agg_filename = "coverage_agg.txt"
+gc_avg_each_sample_coverage_filename = (
+    "GC_bias_with_coverage_averages_over_each_sample.txt"
+)
+gc_bias_with_coverage_filename = "GC_bias_with_coverage.txt"
+read_counts_total_filename = "read_counts_total.txt"
+coverage_per_interval_filename = "coverage_per_interval.txt"
+read_counts_table_exon_level_filename = "read_counts_agg_exon_level.txt"
+coverage_table_exon_level_filename = "coverage_agg_exon_level.txt"
+gc_cov_int_table_exon_level_filename = "GC_bias_with_coverage_exon_level.txt"
+gc_avg_each_sample_coverage_exon_level_filename = (
+    "GC_bias_with_coverage_averages_over_each_sample_exon_level.txt"
+)
+average_coverage_across_exon_targets_filename = (
+    "average_coverage_across_exon_targets_duplex_A.txt"
+)
+
+INSERT_SIZE_PREFIX = "insert_sizes_"
+INSERT_SIZE_OUTPUT_FILE_NAMES = [
+    "standard_A_targets.txt",
+    "unfiltered_A_targets.txt",
+    "simplex_A_targets.txt",
+    "duplex_A_targets.txt",
+    "standard_B_targets.txt",
+    "unfiltered_B_targets.txt",
+    "simplex_B_targets.txt",
+    "duplex_B_targets.txt",
+]
+INSERT_SIZE_OUTPUT_FILE_NAMES = [
+    INSERT_SIZE_PREFIX + o for o in INSERT_SIZE_OUTPUT_FILE_NAMES
+]
+
+ALL_TABLES_MODULE_OUTPUT_FILES = (
+    [
+        read_counts_filename,
+        coverage_agg_filename,
+        gc_avg_each_sample_coverage_filename,
+        gc_bias_with_coverage_filename,
+        read_counts_total_filename,
+        coverage_per_interval_filename,
+        read_counts_table_exon_level_filename,
+        coverage_table_exon_level_filename,
+        gc_cov_int_table_exon_level_filename,
+        gc_avg_each_sample_coverage_exon_level_filename,
+        average_coverage_across_exon_targets_filename,
+    ]
+    + EXON_COVERAGE_OUTPUT_FILE_NAMES
+    + INSERT_SIZE_OUTPUT_FILE_NAMES
+    + ["qc_sample_coverage_A_targets.txt", "qc_sample_coverage_B_targets.txt"]
+)
+
+
+####################
+# Constants for VC #
+####################
+
+# SampleSheet to TitleFile #
+TITLE_FILE_PAIRING_EXPECTED_COLUMNS = ["Sample", "Class", "Patient_ID", "Sample_type"]
+TUMOR_ID = "tumor_id"
+NORMAL_ID = "normal_id"
+SAMPLE_CLASS = "class"
+GROUP_BY_ID = "Patient_ID"
+SAMPLE_PAIR1 = "Sample_x"
+SAMPLE_PAIR2 = "Sample_y"
+CLASS_PAIR1 = "Class_x"
+CLASS_PAIR2 = "Class_y"
+SAMPLE_TYPE_PAIR1 = "Sample_type_x"
+SAMPLE_TYPE_PAIR2 = "Sample_type_y"
+TUMOR_CLASS = "Tumor"
+NORMAL_CLASS = "Normal"
+SAMPLE_TYPE_PLASMA = "Plasma"
+SAMPLE_TYPE_NORMAL_NONPLASMA = "Buffycoat"
+TITLE_FILE_TO_PAIRED_FILE = "Title_file_to_paired.csv"
+
+# Final maf to text #
+MAF_COLUMNS_SELECT = [
+    "Hugo_Symbol",
+    "Chromosome",
+    # "Start_Position",
+    "vcf_pos",
+    "Variant_Classification",
+    # "Reference_Allele",
+    "VCF_REF",
+    # "Tumor_Seq_Allele2",
+    "VCF_ALT",
+    "dbSNP_RS",
+    "Tumor_Sample_Barcode",
+    "caller_Norm_Sample_Barcode",
+    "HGVSc",
+    "HGVSp_Short",
+    "Transcript_ID",
+    "EXON",
+    "INTRON",
+    "GMAF",
+    "D_t_alt_count_fragment",
+    "D_t_ref_count_fragment",
+    "D_t_vaf_fragment",
+    "SD_t_alt_count_fragment",
+    "SD_t_ref_count_fragment",
+    "SD_t_vaf_fragment",
+    "n_alt_count_fragment",
+    "n_ref_count_fragment",
+    "n_vaf_fragment",
+    "CURATED_SIMPLEX_DUPLEX_median_VAF",
+    "CURATED_SIMPLEX_DUPLEX_n_fillout_sample_alt_detect",
+    "CURATED_SIMPLEX_DUPLEX_n_fillout_sample",
+    "NORMAL_median_VAF",
+    "NORMAL_n_fillout_sample_alt_detect",
+    "NORMAL_n_fillout_sample",
+    "CURATED_DUPLEX_median_VAF",
+    "CURATED_DUPLEX_n_fillout_sample_alt_detect",
+    "CURATED_DUPLEX_n_fillout_sample",
+    "gnomAD_AF",
+    "gnomAD_AF_AFR",
+    "gnomAD_AF_AMR",
+    "gnomAD_AF_ASJ",
+    "gnomAD_AF_EAS",
+    "gnomAD_AF_FIN",
+    "gnomAD_AF_NFE",
+    "gnomAD_AF_OTH",
+    "gnomAD_AF_SAS",
+    "CallMethod",
+    "Mutation_Class",
+    "Status",
+    "Cosmic_ID",
+]
+
+MAF_TSV_COL_MAP = OrderedDict(
+    [
+        ("Tumor_Sample_Barcode", "Sample"),
+        ("caller_Norm_Sample_Barcode", "NormalUsed"),
+        ("Chromosome", "Chrom"),
+        # ("Start_Position", "Start"),
+        # ("Reference_Allele", "Ref"),
+        # ("Tumor_Seq_Allele2", "Alt"),
+        ("vcf_pos", "Start"),
+        ("VCF_REF", "Ref"),
+        ("VCF_ALT", "Alt"),
+        ("Variant_Classification", "VariantClass"),
+        ("Hugo_Symbol", "Gene"),
+        ("Call_Confidence", "Call_Confidence"),
+        ("EXON", "Exon"),
+        ("Transcript_ID", "TranscriptID"),
+        ("Comments", "Comments"),
+        ("HGVSc", "cDNAchange"),
+        ("HGVSp_Short", "AAchange"),
+        ("dbSNP_RS", "dbSNP_ID"),
+        ("Cosmic_ID", "Cosmic_ID"),
+        ("GMAF", "1000G_MAF"),
+        ("FailureReason", "FailureReason"),
+        ("CallMethod", "CallMethod"),
+        ("COSMIC_site", "COSMIC_site"),
+        ("n_count_fragment", "N_TotalDepth"),
+        ("n_ref_count_fragment", "N_RefCount"),
+        ("n_alt_count_fragment", "N_AltCount"),
+        ("n_vaf_fragment", "N_AltFreq"),
+        ("T_TotalDepth", "T_TotalDepth"),
+        ("T_RefCount", "T_RefCount"),
+        ("T_AltCount", "T_AltCount"),
+        ("T_AltFreq", "T_AltFreq"),
+        ("T_Ref_Pos", "T_Ref+"),
+        ("T_Ref_Neg", "T_Ref-"),
+        ("T_Alt_Pos", "T_Alt+"),
+        ("T_Alt_Neg", "T_Alt-"),
+        ("Strand_Bias", "Strand_Bias"),
+        ("NORMAL_n_fillout_sample_alt_detect", "All_N_Aggregate_AlleleDepth"),
+        ("NORMAL_median_VAF", "All_N_Median_AlleleFreq"),
+        ("SD_t_vaf_fragment_over_n_vaf_fragment", "T_freq/All_N_Freq"),
+        ("NORMAL_n_fillout_sample", "Occurence_in_Normals"),
+        ("gnomAD_Max_AF", "gnomAD_Max_AF"),
+        ("gnomAD_AF", "gnomAD_ALL"),
+        ("gnomAD_AF_AFR", "gnomAD_AFR"),
+        ("gnomAD_AF_AMR", "gnomAD_AMR"),
+        ("gnomAD_AF_ASJ", "gnomAD_ASJ"),
+        ("gnomAD_AF_EAS", "gnomAD_EAS"),
+        ("gnomAD_AF_FIN", "gnomAD_FIN"),
+        ("gnomAD_AF_NFE", "gnomAD_NFE"),
+        ("gnomAD_AF_OTH", "gnomAD_OTH"),
+        ("gnomAD_AF_SAS", "gnomAD_SAS"),
+        ("Mutation_Class", "Mutation_Class"),
+        ("Status", "Mutation_Status"),
+        ("D_t_count_fragment", "D_T_TotalDepth"),
+        ("D_t_ref_count_fragment", "D_T_RefCount"),
+        ("D_t_alt_count_fragment", "D_T_AltCount"),
+        ("D_t_vaf_fragment", "D_T_AltFreq"),
+        ("S_t_count_fragment", "S_T_TotalDepth"),
+        ("S_t_ref_count_fragment", "S_T_RefCount"),
+        ("S_t_alt_count_fragment", "S_T_AltCount"),
+        ("S_t_vaf_fragment", "S_T_AltFreq"),
+        ("SD_t_count_fragment", "SD_T_TotalDepth"),
+        ("SD_t_ref_count_fragment", "SD_T_RefCount"),
+        ("SD_t_alt_count_fragment", "SD_T_AltCount"),
+        ("SD_t_vaf_fragment", "SD_T_AltFreq"),
+        (
+            "CURATED_DUPLEX_n_fillout_sample_alt_detect",
+            "D_All_curatedN_Aggregate_AlleleDepth",
+        ),
+        ("CURATED_DUPLEX_median_VAF", "D_All_curatedN_Median_AlleleFreq"),
+        ("CURATED_DUPLEX_n_fillout_sample", "D_Occurrence_in_Curated_Normals"),
+        (
+            "CURATED_SIMPLEX_DUPLEX_n_fillout_sample_alt_detect",
+            "SD_All_curatedN_Aggregate_AlleleDepth",
+        ),
+        ("CURATED_SIMPLEX_DUPLEX_median_VAF", "SD_All_curatedN_Median_AlleleFreq"),
+        ("CURATED_SIMPLEX_DUPLEX_n_fillout_sample", "SD_Occurrence_in_Curated_Normals"),
+    ]
+)
+
+MAF_DUMMY_COLUMNS = [
+    "Call_Confidence",
+    "Comments",
+    "Strand_Bias",
+    "COSMIC_site",
+    "FailureReason",
+    "T_TotalDepth",
+    "T_RefCount",
+    "T_AltCount",
+    "T_AltFreq",
+    "T_Ref_Pos",
+    "T_Ref_Neg",
+    "T_Alt_Pos",
+    "T_Alt_Neg",
+]
+
+GNOMAD_COLUMNS = [
+    "gnomAD_AF",
+    "gnomAD_AF_AFR",
+    "gnomAD_AF_AMR",
+    "gnomAD_AF_ASJ",
+    "gnomAD_AF_EAS",
+    "gnomAD_AF_FIN",
+    "gnomAD_AF_NFE",
+    "gnomAD_AF_OTH",
+    "gnomAD_AF_SAS",
+]
+
+MAF_DUMMY_COLUMNS2 = [
+    "cosmic_ID",
+    "cosmic_OCCURENCE",
+    "GMAF",
+    "Mutation_Class",
+    "gnomAD_AF",
+    "gnomAD_AF_AFR",
+    "gnomAD_AF_AMR",
+    "gnomAD_AF_ASJ",
+    "gnomAD_AF_EAS",
+    "gnomAD_AF_FIN",
+    "gnomAD_AF_NFE",
+    "gnomAD_AF_OTH",
+    "gnomAD_AF_SAS",
+    "CURATED_DUPLEX_median_VAF",
+    "CURATED_DUPLEX_n_fillout_sample",
+    "CURATED_DUPLEX_n_fillout_sample_alt_detect",
+    "CURATED_SIMPLEX_DUPLEX_median_VAF",
+    "CURATED_SIMPLEX_DUPLEX_n_fillout_sample",
+    "CURATED_SIMPLEX_DUPLEX_n_fillout_sample_alt_detect",
+]
+
+# Filename variables
+EXONIC_FILTERED = "_ExonicFiltered.pre_traceback.txt"
+EXONIC_DROPPED = "_ExonicDropped.pre_traceback.txt"
+SILENT_FILTERED = "_SilentFiltered.pre_traceback.txt"
+SILENT_DROPPED = "_SilentDropped.pre_traceback.txt"
+NONPANEL_EXONIC_FILTERED = "_NonPanelExonicFiltered.txt"
+NONPANEL_EXONIC_DROPPED = "_NonPanelExonicDropped.txt"
+NONPANEL_SILENT_FILTERED = "_NonPanelSilentFiltered.txt"
+NONPANEL_SILENT_DROPPED = "_NonPanelSilentDropped.txt"
+
+EXONIC_FILTERED = "annotated_exonic_variants.txt"
+SILENT_FILTERED = "annotated_silent_variants.txt"
+NONPANEL_EXONIC_FILTERED = "annotated_nonpanel_exonic_variants.txt"
+NONPANEL_SILENT_FILTERED = "annotated_nonpanel_silent_variants.txt"
+DROPPED = "annotated_dropped_variants.txt"
+
+# Filtering functions and variables
+ALLOWED_EXONIC_VARIANT_CLASS = [
+    "Frame_Shift_Del",
+    "Frame_Shift_Ins",
+    "In_Frame_Del",
+    "In_Frame_Ins",
+    "Missense_Mutation",
+    "Nonsense_Mutation",
+    "Nonstop_Mutation",
+    "Splice_Site",
+    "Translation_Start_Site",
+]
+
+
+def IS_EXONIC_CLASS(Gene, VariantClass, Coordinate):
+    """
+    Determine whether a variant can be considered as exonic
+    based on user-defined conditions. Multiple user-defined 
+    conditions can be added to the conditional block.
+    """
+    if any(
+        [
+            VariantClass in ALLOWED_EXONIC_VARIANT_CLASS,
+            Gene == "TERT" and VariantClass == "5'Flank",
+        ]
+    ):
+        return (Gene, VariantClass, Coordinate)
+    elif any(
+        [
+            Gene == "MET"
+            and VariantClass == "Intron"
+            and Coordinate >= 116411708
+            and Coordinate <= 116414935
+        ]
+    ):
+        return (Gene, "Splice_Site", Coordinate)
+    else:
+        return None
+
+
+#########
+# Noise #
+#########
+
+NOISE_HEADER = [
+    SAMPLE_ID_COLUMN,
+    "GenotypeCount",
+    "AltCount",
+    "AltPercent",
+    "ContributingSites",
+    "Method",
+]
+
+
+########################
+# Cleanup Outputs Step #
+########################
+
+TMPDIR_SEARCH = re.compile(r"(^tmp$|^tmp......$)")
+OUT_TMPDIR_SEARCH = re.compile(r"^out_tmpdir......$")
+TOIL_LOG = re.compile(r"(^toil_job_[0-9]+.[o|e][0-9]+$)")
+
+STANDARD_BAM_DIR = "standard"
+UNFILTERED_BAM_DIR = "unfiltered"
+SIMPLEX_BAM_DIR = "simplex"
+DUPLEX_BAM_DIR = "duplex"
+TRIM_FILES_DIR = "trimming_results"
+MARK_DUPLICATES_FILES_DIR = "mark_duplicates_results"
+COVERED_INTERVALS_DIR = "covered_intervals_results"
+
+BAM_FILE_REGEX = re.compile(r"\.bam$")
+STANDARD_BAM_SEARCH = re.compile(r"^.*_cl_aln_srt_MD_IR_FX_BR.bam$")
+UNFILTERED_BAM_SEARCH = re.compile(r"^.*_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX.bam$")
+SIMPLEX_BAM_SEARCH = re.compile(
+    r"^.*_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-simplex.bam$"
+)
+DUPLEX_BAM_SEARCH = re.compile(r"^.*_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-duplex.bam$")
+STANDARD_BAI_SEARCH = re.compile(r"^.*_cl_aln_srt_MD_IR_FX_BR.bai$")
+UNFILTERED_BAI_SEARCH = re.compile(r"^.*_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX.bai$")
+SIMPLEX_BAI_SEARCH = re.compile(
+    r"^.*_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-simplex.bai$"
+)
+DUPLEX_BAI_SEARCH = re.compile(r"^.*_cl_aln_srt_MD_IR_FX_BR__aln_srt_IR_FX-duplex.bai$")
+
+TRIM_FILE_SEARCH = re.compile(r"^.*_cl\.stats$")
+MARK_DUPLICATES_FILE_SEARCH = re.compile(r"^.*\.md_metrics$")
+COVERED_INTERVALS_FILE_SEARCH = re.compile(r"^.*(\.fci\.bed\.srt|\.fci\.list)$")
+
+BAM_DIRS = [STANDARD_BAM_DIR, UNFILTERED_BAM_DIR, SIMPLEX_BAM_DIR, DUPLEX_BAM_DIR]
+
+BAM_SEARCHES = [
+    STANDARD_BAM_SEARCH,
+    UNFILTERED_BAM_SEARCH,
+    SIMPLEX_BAM_SEARCH,
+    DUPLEX_BAM_SEARCH,
+]

--- a/postprocessing_variant_calls/maf/tag/tag_process.py
+++ b/postprocessing_variant_calls/maf/tag/tag_process.py
@@ -297,10 +297,9 @@ def split_by_annotations(
     ),
 ):
     # prep maf
-    print("test")
     typer.secho(f"Reading in input filtered MAF file.", fg=typer.colors.BRIGHT_GREEN)
-    # mafa = MAFFile(maf, separator)
-    # test = mafa.split_by_annotations_subset()
+    mafa = MAFFile(maf, separator)
+    test = mafa.split_by_annotations_subset()
     # print(test)
     
     

--- a/postprocessing_variant_calls/maf/tag/tag_process.py
+++ b/postprocessing_variant_calls/maf/tag/tag_process.py
@@ -299,7 +299,7 @@ def split_by_annotations(
     # prep maf
     typer.secho(f"Reading in input filtered MAF file.", fg=typer.colors.BRIGHT_GREEN)
     mafa = MAFFile(maf, separator)
-    test = mafa.split_by_annotations_subset()
+    mafa.split_by_annotations_subset()
     # print(test)
     
     

--- a/postprocessing_variant_calls/maf/tag/tag_process.py
+++ b/postprocessing_variant_calls/maf/tag/tag_process.py
@@ -268,5 +268,46 @@ def traceback(
     return 0
 
 
+@app.command(
+    "split_by_annotations",
+    help="Tag filtered MAF file with various annotations and subset into individual text files.",
+)
+def split_by_annotations(
+    maf: Path = typer.Option(
+        ...,
+        "--maf",
+        "-m",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        writable=False,
+        readable=True,
+        resolve_path=True,
+        help="filtered MAF file to split by annotations with",
+    ),
+    output: Path = typer.Option(
+        "output", "--output", "-o", help="Maf output file name."
+    ),
+    separator: str = typer.Option(
+        "tsv",
+        "--separator",
+        "-sep",
+        help="Specify a seperator for delimited data.",
+        callback=check_separator,
+    ),
+):
+    # prep maf
+    print("test")
+    typer.secho(f"Reading in input filtered MAF file.", fg=typer.colors.BRIGHT_GREEN)
+    # mafa = MAFFile(maf, separator)
+    # test = mafa.split_by_annotations_subset()
+    # print(test)
+    
+    
+    # include the various tagging functions here (all will be in the MAF class)
+    #mafa = mafa.tag("")
+    return 0
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
<!--
# msk/nucleovar pull request

Many thanks for contributing to msk/nucleovar!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/msk/nucleovar/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/msk/nucleovar/tree/master/.github/CONTRIBUTING.md)
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
- [ ] create split by annotations command in maf tag 
- [ ] create separate mini tagging functions for each text file created in split by annotations (exonic,silent,nonpanel_exonic,nonpanel_silent,dropped)
- [ ] turn exonic text file into a MAF output too (so it can be used for the IGV loader script)
